### PR TITLE
config: enable chore and deps commits for release-please

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -6,7 +6,16 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "include-component-in-tag": false,
-      "include-v-in-tag": true
+      "include-v-in-tag": true,
+      "extra-files": [],
+      "versioning": "default",
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "perf", "section": "Performance Improvements"},
+        {"type": "chore", "section": "Dependencies"},
+        {"type": "deps", "section": "Dependencies"}
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/renovate.json5
+++ b/renovate.json5
@@ -32,10 +32,6 @@
       enabled: true,
     },
   ],
-  // Configure commit message format for dependency updates
-  commitMessagePrefix: 'chore(deps):',
-  commitMessageAction: 'update',
-  commitMessageTopic: 'dependencies',
   customManagers: [
     {
       customType: 'regex',

--- a/renovate.json5
+++ b/renovate.json5
@@ -32,6 +32,10 @@
       enabled: true,
     },
   ],
+  // Configure commit message format for dependency updates
+  commitMessagePrefix: 'chore(deps):',
+  commitMessageAction: 'update',
+  commitMessageTopic: 'dependencies',
   customManagers: [
     {
       customType: 'regex',


### PR DESCRIPTION
Enable chore(deps): commits to trigger new releases

- Add changelog sections for chore and deps commit types
- This will make chore(deps): commits trigger new releases
- Users will now get version bumps for dependency updates

Fixes the issue where dependency updates weren't creating new releases.