### PR TITLE
chore: update YAML v2 to v2.4.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.0 // indirect
 	go.uber.org/mock v0.6.0 // indirect
-	go.yaml.in/yaml/v2 v2.4.2 // indirect
+	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.21.0 // indirect
 	golang.org/x/crypto v0.42.0 // indirect


### PR DESCRIPTION
## Summary
This PR updates the YAML v2 dependency to the latest version:
- Updated YAML v2 from v2.4.2 to v2.4.3 (kept as indirect for Prometheus compatibility)
- Maintains existing YAML v3 usage

## Changes
- Updated `go.mod` with latest YAML v2 version
- All linters pass with 0 issues
- No breaking changes

## Testing
- ✅ All linters pass
- ✅ Dependencies resolve correctly
- ✅ No breaking changes