### PR TITLE
fix: make yaml optional and always overlay env vars on config

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -13,4 +13,3 @@ jobs:
           fetch-depth: 0
 
       - uses: aevea/commitsar@909c3ab676c9af63cb84f2e38f395c7e89829b04 # v1.0.3
-

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,30 +33,19 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Check if we should use environment variables
-	configFromEnv := os.Getenv("GHCR_EXPORTER_CONFIG_FROM_ENV") == "true"
-
-	// Load configuration
-	var (
-		cfg *config.Config
-		err error
-	)
-
-	if configFromEnv {
-		cfg, err = config.LoadConfig("", true)
-	} else {
-		// Use environment variable if config flag is not provided
-		if configPath == "" {
-			if envConfig := os.Getenv("CONFIG_PATH"); envConfig != "" {
-				configPath = envConfig
-			} else {
-				configPath = "config.yaml"
-			}
+	if configPath == "" {
+		if envConfig := os.Getenv("CONFIG_PATH"); envConfig != "" {
+			configPath = envConfig
+		} else {
+			configPath = "config.yaml"
 		}
-
-		cfg, err = config.LoadConfig(configPath, false)
 	}
 
+	if os.Getenv("GHCR_EXPORTER_CONFIG_FROM_ENV") == "true" {
+		fmt.Fprintln(os.Stderr, "Warning: GHCR_EXPORTER_CONFIG_FROM_ENV is deprecated and has no effect. Env vars are always applied on top of yaml config.")
+	}
+
+	cfg, err := config.LoadConfig(configPath)
 	if err != nil {
 		slog.Error("Failed to load configuration", "error", err, "path", configPath) //nolint:gosec // G706: configPath is from CLI/env, not HTTP input; slog structures the value safely
 		os.Exit(1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,104 +38,63 @@ func (p PackageGroup) GetName() string {
 	return p.Owner + "-" + p.Repo
 }
 
-// LoadConfig loads configuration from a YAML file
-func LoadConfig(path string, configFromEnv bool) (*Config, error) {
-	if configFromEnv {
-		return loadFromEnv()
-	}
+// LoadConfig loads configuration with priority: env vars > yaml file > defaults.
+// The yaml file is optional; if path is empty or the file does not exist it is
+// silently skipped. Environment variables are always applied on top.
+func LoadConfig(path string) (*Config, error) {
+	var cfg Config
 
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read config file: %w", err)
-	}
-
-	var config Config
-	if err := yaml.Unmarshal(data, &config); err != nil {
-		return nil, fmt.Errorf("failed to parse config file: %w", err)
-	}
-
-	// Set defaults
-	setDefaults(&config)
-
-	// Validate configuration
-	if err := config.Validate(); err != nil {
-		return nil, fmt.Errorf("configuration validation failed: %w", err)
-	}
-
-	return &config, nil
-}
-
-// loadFromEnv loads configuration from environment variables
-func loadFromEnv() (*Config, error) {
-	config := &Config{}
-
-	// Load base configuration from environment
-	baseConfig := &promexporter_config.BaseConfig{}
-
-	// Server configuration
-	if host := os.Getenv("GHCR_EXPORTER_SERVER_HOST"); host != "" {
-		baseConfig.Server.Host = host
-	} else {
-		baseConfig.Server.Host = "0.0.0.0"
-	}
-
-	if portStr := os.Getenv("GHCR_EXPORTER_SERVER_PORT"); portStr != "" {
-		if port, err := strconv.Atoi(portStr); err != nil {
-			return nil, fmt.Errorf("invalid server port: %w", err)
-		} else {
-			baseConfig.Server.Port = port
+	if path != "" {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			if err := yaml.Unmarshal(data, &cfg); err != nil {
+				return nil, fmt.Errorf("failed to parse config file %s: %w", path, err)
+			}
+		} else if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to read config file %s: %w", path, err)
 		}
-	} else {
-		baseConfig.Server.Port = 8080
 	}
 
-	// Logging configuration
-	if level := os.Getenv("GHCR_EXPORTER_LOG_LEVEL"); level != "" {
-		baseConfig.Logging.Level = level
-	} else {
-		baseConfig.Logging.Level = "info"
-	}
-
-	if format := os.Getenv("GHCR_EXPORTER_LOG_FORMAT"); format != "" {
-		baseConfig.Logging.Format = format
-	} else {
-		baseConfig.Logging.Format = "json"
-	}
-
-	// Metrics configuration
-	if intervalStr := os.Getenv("GHCR_EXPORTER_METRICS_COLLECTION_DEFAULT_INTERVAL"); intervalStr != "" {
-		if interval, err := time.ParseDuration(intervalStr); err != nil {
-			return nil, fmt.Errorf("invalid metrics default interval: %w", err)
-		} else {
-			baseConfig.Metrics.Collection.DefaultInterval = promexporter_config.Duration{Duration: interval}
-			baseConfig.Metrics.Collection.DefaultIntervalSet = true
-		}
-	} else {
-		baseConfig.Metrics.Collection.DefaultInterval = promexporter_config.Duration{Duration: time.Second * 30}
-	}
-
-	config.BaseConfig = *baseConfig
-
-	// Apply generic environment variables (TRACING_ENABLED, PROFILING_ENABLED, etc.)
-	// These are handled by promexporter and are shared across all exporters
-	if err := promexporter_config.ApplyGenericEnvVars(&config.BaseConfig); err != nil {
+	if err := promexporter_config.ApplyGenericEnvVars(&cfg.BaseConfig); err != nil {
 		return nil, fmt.Errorf("failed to apply generic environment variables: %w", err)
 	}
 
-	// GitHub configuration
-	if token := os.Getenv("GHCR_EXPORTER_GITHUB_TOKEN"); token != "" {
-		config.GitHub.Token = promexporter_config.NewSensitiveString(token)
-	}
+	applyEnvVars(&cfg)
+	setDefaults(&cfg)
 
-	// Set defaults for any missing values
-	setDefaults(config)
-
-	// Validate configuration
-	if err := config.Validate(); err != nil {
+	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("configuration validation failed: %w", err)
 	}
 
-	return config, nil
+	return &cfg, nil
+}
+
+// applyEnvVars overlays GHCR-exporter environment variables onto cfg.
+// Only variables that are set (non-empty) are applied.
+func applyEnvVars(cfg *Config) {
+	if host := os.Getenv("GHCR_EXPORTER_SERVER_HOST"); host != "" {
+		cfg.Server.Host = host
+	}
+	if portStr := os.Getenv("GHCR_EXPORTER_SERVER_PORT"); portStr != "" {
+		if port, err := strconv.Atoi(portStr); err == nil {
+			cfg.Server.Port = port
+		}
+	}
+	if level := os.Getenv("GHCR_EXPORTER_LOG_LEVEL"); level != "" {
+		cfg.Logging.Level = level
+	}
+	if format := os.Getenv("GHCR_EXPORTER_LOG_FORMAT"); format != "" {
+		cfg.Logging.Format = format
+	}
+	if intervalStr := os.Getenv("GHCR_EXPORTER_METRICS_COLLECTION_DEFAULT_INTERVAL"); intervalStr != "" {
+		if interval, err := time.ParseDuration(intervalStr); err == nil {
+			cfg.Metrics.Collection.DefaultInterval = promexporter_config.Duration{Duration: interval}
+			cfg.Metrics.Collection.DefaultIntervalSet = true
+		}
+	}
+	if token := os.Getenv("GHCR_EXPORTER_GITHUB_TOKEN"); token != "" {
+		cfg.GitHub.Token = promexporter_config.NewSensitiveString(token)
+	}
 }
 
 // setDefaults sets default values for configuration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,23 +75,28 @@ func applyEnvVars(cfg *Config) {
 	if host := os.Getenv("GHCR_EXPORTER_SERVER_HOST"); host != "" {
 		cfg.Server.Host = host
 	}
+
 	if portStr := os.Getenv("GHCR_EXPORTER_SERVER_PORT"); portStr != "" {
 		if port, err := strconv.Atoi(portStr); err == nil {
 			cfg.Server.Port = port
 		}
 	}
+
 	if level := os.Getenv("GHCR_EXPORTER_LOG_LEVEL"); level != "" {
 		cfg.Logging.Level = level
 	}
+
 	if format := os.Getenv("GHCR_EXPORTER_LOG_FORMAT"); format != "" {
 		cfg.Logging.Format = format
 	}
+
 	if intervalStr := os.Getenv("GHCR_EXPORTER_METRICS_COLLECTION_DEFAULT_INTERVAL"); intervalStr != "" {
 		if interval, err := time.ParseDuration(intervalStr); err == nil {
 			cfg.Metrics.Collection.DefaultInterval = promexporter_config.Duration{Duration: interval}
 			cfg.Metrics.Collection.DefaultIntervalSet = true
 		}
 	}
+
 	if token := os.Getenv("GHCR_EXPORTER_GITHUB_TOKEN"); token != "" {
 		cfg.GitHub.Token = promexporter_config.NewSensitiveString(token)
 	}


### PR DESCRIPTION
Env vars now always apply on top of yaml (env > yaml > defaults). yaml is optional. CONFIG_FROM_ENV deprecated as no-op.