### PR TITLE
fix: use RELEASE_TOKEN in auto-format workflow to trigger CI

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref || github.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
## Summary

- Switch the `auto-format` workflow to use `RELEASE_TOKEN` (fine-grained PAT) instead of the built-in `GITHUB_TOKEN` for the checkout step
- Commits pushed by the auto-format bot now trigger CI, because `GITHUB_TOKEN`-based pushes are intentionally blocked from re-triggering workflows by GitHub

## Test plan

- [ ] Confirm the auto-format workflow pushes a commit when formatting changes are needed
- [ ] Confirm CI runs are triggered by that commit