### PR TITLE
chore: remove deprecated CONFIG_FROM_ENV env var

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,10 +41,6 @@ func main() {
 		}
 	}
 
-	if os.Getenv("GHCR_EXPORTER_CONFIG_FROM_ENV") == "true" {
-		fmt.Fprintln(os.Stderr, "Warning: GHCR_EXPORTER_CONFIG_FROM_ENV is deprecated and has no effect. Env vars are always applied on top of yaml config.")
-	}
-
 	cfg, err := config.LoadConfig(configPath)
 	if err != nil {
 		slog.Error("Failed to load configuration", "error", err, "path", configPath)


### PR DESCRIPTION
## Summary
The env var has been documented as deprecated/no-op for several releases. Env vars are always applied on top of yaml config unconditionally, so the deprecation warning is the only thing this code does. Drop the warning block.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`