### PR TITLE
chore: standardize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ version: "2"
 
 run:
   timeout: 5m
-  go: "1.25.1"
+  go: "1.25.0"
 
 linters:
   # Use fast linters for better performance
@@ -43,6 +43,8 @@ linters:
     - usetesting  # Not critical
     - varnamelen  # Variable names fine
     - wsl  # Use wsl_v5 instead
+    - gocyclo  # Allow complex functions for SNMP data processing
+    - maintidx  # Allow complex registry functions
 
   settings:
     gosec:


### PR DESCRIPTION
Align `.golangci.yml` with the shared canonical config used across the exporter repos.

## Changes
- Adopt canonical `.golangci.yml` (only functional delta: adds `gocyclo` and `maintidx` to the disabled linters list).
- `run.go` set to `1.25.0` to match this repo's `go.mod`.

CI already runs golangci-lint via the `lint` job (`make lint-only`, golangci-lint v2.12.2 in Docker), so no workflow change is needed.

Local `golangci-lint run --fix ./...` reports **0 issues**. `go test ./...` passes.